### PR TITLE
Bring back pooling.

### DIFF
--- a/source/CsvBenchmark/CsvReaderBenchmarks.cs
+++ b/source/CsvBenchmark/CsvReaderBenchmarks.cs
@@ -207,10 +207,20 @@ namespace CsvBenchmark
 		}
 
 		[Benchmark]
-		public void CursivelyCsv()
+		public void CursivelyCsvNoPooling()
 		{
 			var d = TestData.GetUtf8Array();
 			var proc = new CursivelyStringVisitor(false);
+			CsvSyncInput
+				.ForMemory(d)
+				.Process(proc);
+		}
+
+		[Benchmark]
+		public void CursivelyCsvWithPooling()
+		{
+			var d = TestData.GetUtf8Array();
+			var proc = new CursivelyStringVisitor(true);
 			CsvSyncInput
 				.ForMemory(d)
 				.Process(proc);
@@ -256,10 +266,19 @@ namespace CsvBenchmark
 		}
 
 		[Benchmark]
-		public void Sylvan()
+		public void SylvanNoPooling()
 		{
 			using var tr = TestData.GetTextReader();
 			var opts = new CsvDataReaderOptions { BufferSize = BufferSize };
+			using var dr = CsvDataReader.Create(tr, opts);
+			dr.ProcessStrings();
+		}
+
+		[Benchmark]
+		public void SylvanWithPooling()
+		{
+			using var tr = TestData.GetTextReader();
+			var opts = new CsvDataReaderOptions { BufferSize = BufferSize, StringFactory = StringPool.Pool };
 			using var dr = CsvDataReader.Create(tr, opts);
 			dr.ProcessStrings();
 		}

--- a/source/CsvBenchmark/CursivelyVisitors.cs
+++ b/source/CsvBenchmark/CursivelyVisitors.cs
@@ -28,8 +28,8 @@ namespace CsvBenchmark
 				chunk = new ReadOnlySpan<byte>(bytes, 0, bytesUsed + chunk.Length);
 				bytesUsed = 0;
 			}
-			var str = doPooling && chunk.Length == 1 && chunk[0] < 128
-				? StringPool.Strings[chunk[0]]
+			var str = doPooling
+				? StringPool.PoolUtf8(chunk)
 				: Encoding.UTF8.GetString(chunk);
 			ordinal++;
 		}

--- a/source/CsvBenchmark/StringPool.cs
+++ b/source/CsvBenchmark/StringPool.cs
@@ -1,8 +1,11 @@
-﻿namespace CsvBenchmark
+﻿using System;
+using System.Text;
+
+namespace CsvBenchmark
 {
 	internal static class StringPool
 	{
-		internal static readonly string[] Strings = new string[128];
+		private static readonly string[] Strings = new string[128];
 
 		static StringPool()
 		{
@@ -10,6 +13,21 @@
 			{
 				Strings[i] = ((char)i).ToString();
 			}
+		}
+
+		internal static string PoolUtf8(ReadOnlySpan<byte> buf)
+		{
+			if (buf.IsEmpty)
+			{
+				return string.Empty;
+			}
+
+			if (buf.Length == 1 && buf[0] < 128)
+			{
+				return Strings[buf[0]];
+			}
+
+			return Encoding.UTF8.GetString(buf);
 		}
 
 		internal static string Pool(char[] buf, int offset, int length)


### PR DESCRIPTION
Cursively, in particular, doesn't do a fantastic job out-of-the-box at producing a separate `string` value for each field, and that's not really its focus.  Rather, its focus is on narrowly implementing the processing for the CSV format as efficiently as possible, and then *enabling* the caller to use their knowledge of the data format and their application's specific needs to do the bare minimum amount of work to bring it the rest of the way.

This can lead to shrink-wrapped Cursively visitor implementations tending to underperform in benchmarks like `CsvReaderBenchmarks` (because the UTF-16 transcoding routine has to keep starting and stopping between fields), whereas there isn't quite as much of a penalty in benchmarks like `CsvReaderSelectBenchmarks` that only need to look at fewer than 4% of the fields of the input.

However, given that this kind of data set is populated with lots of low integer values, a simple string pool like the one you created for Sylvan is sufficient to justify why a "high-performance" library like Cursively appears so slow: **merely** removing the `string` allocation / transcoding / copying step from a subset of the fields whose data requires no more than a single byte brings Cursively's running time down to a little more than 50% of Sylvan on my machine, and memory allocation drops down significantly.

In fairness, that string pool also helps Sylvan, but not quite as much: Cursively still takes only a little more than 67% of the time as Sylvan even when both are using the string pool.  Again, on my machine.

I suspect that you remove the pooling implementations during the most recent reorganization because `[Arguments]` seems to break the Ratio column, so I just copy-pasted in order to have it run both versions.

For convenience, running this command in `source\CsvBenchmark` will run just the four benchmark methods touched by this PR:
```
dotnet run -c Release -- --iterationTime 1000 --filter "*Pooling"
```